### PR TITLE
correct import statement to run examples/RDSM on PBC Dataset.ipynb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+*~
+.idea/
+*.pyc
+*.ipynb
+activate
+**/.ipynb_checkpoints

--- a/dsm/__init__.py
+++ b/dsm/__init__.py
@@ -221,8 +221,8 @@ user/themes/auton/images/AutonLogo.png">
 
 """
 
-from dsm.dsm_api import DeepSurvivalMachines
-from dsm.dsm_api import DeepConvolutionalSurvivalMachines
-from dsm.dsm_api import DeepRecurrentSurvivalMachines
-from dsm.dsm_api import DeepCNNRNNSurvivalMachines
+from auton_survival.models.dsm import DeepSurvivalMachines
+from auton_survival.models.dsm import DeepConvolutionalSurvivalMachines
+from auton_survival.models.dsm import DeepRecurrentSurvivalMachines
+from auton_survival.models.dsm import DeepCNNRNNSurvivalMachines
 from dsm.contrib.dcm.dcm_api import DeepCoxMixtures


### PR DESCRIPTION
Hi!

I had to modify line 224 of `dsm/__init__.py` to run the `examples/RDSM on PBC Dataset.ipynb` notebook:

`from dsm.dsm_api import DeepSurvivalMachines` to `from auton_survival.models.dsm import DeepSurvivalMachines`

Also, I see in the documentation (`auton-survival/docs/models/dsm/index.html`) that `DeepConvolutionalSurvivalMachines` are not implemented yet, but the code is there. Is the documentation outdated, or is there a good reason not to use this class?

Best,
Georges