### PR TITLE
Packaged project using the flit build system

### DIFF
--- a/auton_survival/__init__.py
+++ b/auton_survival/__init__.py
@@ -468,7 +468,7 @@ SOFTWARE.
 
 '''
 
-__version__ = "0.1.0"
+__version__ = "1.0.0"
 
 
 from .models.dsm import DeepSurvivalMachines

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,25 @@
+[project]
+name = "auton_survival"
+version = "1.0.0"
+description = "The auton-survival package contains reusable utilities for projects involving censored Time-to-Event Data. "
+authors = [
+  { name = "Chirag Nagpal", email = "chiragn@cs.cmu.edu" }
+]
+license = {file = "LICENSE"}
+readme = "README.md"
+requires-python = ">=3.9"
+dependencies = [
+    "torch>=1.0.0",
+    "numpy>=1.16.5",
+    "pandas>=1.0.0",
+    "tqdm>=4.0.0",
+    "scikit-learn>=0.18",
+    "torchvision>=0.7.0",
+    "scikit-survival>=0.15.0",
+    "lifelines>=0.26.4",
+]
+
+[build-system]
+requires = ["flit_core >=3.2,<4"]
+build-backend = "flit_core.buildapi"
+


### PR DESCRIPTION
I am contributing this simple patch as one of the possible solutions to issue #87

Just bult a very simple pyproject .toml that uses [flit](https://flit.pypa.io/en/stable/index.html) as a build system for the package.
This patch allows both for installation via pip from a local clone or directly from github. 