### PR TITLE
feat: trigger first release on PyPI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -96,7 +96,7 @@ jobs:
           poetry config pypi-token.test-pypi $TEST_PYPI_TOKEN
           poetry publish -r test-pypi -u __token__
 
-      - if: false && steps.release-status.outputs.released == 'true'
+      - if: steps.release-status.outputs.released == 'true'
         name: Release to PyPI
         id: pypi-release
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,7 @@ jobs:
   Release:
     needs: Quality
     if: |
+      github.repository == 'autonlab/auton-survival' && 
       github.event_name == 'push' && 
       github.ref == 'refs/heads/master' && 
       !contains ( github.event.head_commit.message, 'chore(release)' )


### PR DESCRIPTION
Merge this PR to publish the first release on PyPI 🎉 (Fixes #87)

⚠️⚠️⚠️ Before merging this PR make sure that the GitHub Repository Secret `PYPI_TOKEN` is correctly set to your PyPI API Token. Token privileges should be for all projects, so that the new project is created and published it in one go. ⚠️⚠️⚠️